### PR TITLE
remove non-existing port_proxy_extension.rb file from Manifest

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -79,7 +79,6 @@ lib/vizkit/vizkit.rb
 lib/vizkit/widget_task_connector.rb
 lib/vizkit/typelib_qt_adapter.rb
 lib/vizkit/qt_orocos.rb
-lib/vizkit/port_proxy_extensions.rb
 lib/vizkit/uiloader.rb
 lib/vizkit/plugin_extensions.rb
 lib/vizkit/plugin_accessor.rb


### PR DESCRIPTION
Sorry ... Failed to notice it in my original PR.
