### PR TITLE
fixed 2d plotting of quaternions

### DIFF
--- a/lib/vizkit/cplusplus_extensions/plot2d.rb
+++ b/lib/vizkit/cplusplus_extensions/plot2d.rb
@@ -235,9 +235,9 @@ Vizkit::UiLoader::extend_cplusplus_widget_class "Plot2d" do
 
     def update_orientation(sample,name)
         rename_graph(name,name+"_yaw")
-        update(sample.yaw   *(180.00/Math::PI),name+"_yaw")
-        update(sample.pitch *(180.00/Math::PI),name+"_pitch")
-        update(sample.roll   *(180.00/Math::PI),name+"_roll")
+        update((sample.yaw)   *(180.00/Math::PI),name+"_yaw")
+        update((sample.pitch) *(180.00/Math::PI),name+"_pitch")
+        update((sample.roll)   *(180.00/Math::PI),name+"_roll")
     end
 
     def update_vector3d(sample,name)


### PR DESCRIPTION
Adding some brackets solves the problem with plotting quaternoins using the plot2d widget.
