### PR TITLE
Rock transformer

### DIFF
--- a/bin/rock-transformer
+++ b/bin/rock-transformer
@@ -3,6 +3,7 @@
 require 'vizkit'
 
 class TransformerStatusWindow < Qt::Widget
+    attr_reader :main_layout
     attr_reader :vizkit3d, :rbs_setter_toolbox, :reload_button
 
     attr_reader :rbs_cache
@@ -21,7 +22,7 @@ class TransformerStatusWindow < Qt::Widget
     attr_predicate :live?
 
     def create_ui
-        main_layout = Qt::VBoxLayout.new(self)
+        @main_layout = Qt::VBoxLayout.new(self)
         splitter = Qt::Splitter.new
         main_layout.add_widget(splitter)
 
@@ -53,7 +54,7 @@ class TransformerStatusWindow < Qt::Widget
 
     def load_conf(path)
         conf = Transformer::Configuration.new
-        conf.load(ARGV.first)
+        conf.load(path)
         conf.each_static_transform do |trsf|
             vizkit3d.setTransformation(trsf.to.dup, trsf.from.dup, trsf.translation.to_qt, trsf.rotation.to_qt)
         end
@@ -106,11 +107,35 @@ class TransformerStatusWindow < Qt::Widget
     end
 end
 
-w = TransformerStatusWindow.new
-w.load_conf(ARGV.first)
+options = Hash.new
+replay = Array.new
+ref_frame = nil
+option_parser = OptionParser.new do |opt|
+    opt.on '--live' do |flag|
+        options[:live] = flag
+    end
+    opt.on '--replay=FILE_OR_DIR', String do |arg|
+        replay << arg
+        options[:live] = true
+    end
+    opt.on '--ref=FRAME', String do |arg|
+        ref_frame = arg
+    end
+end
 
-if reference_frame = ARGV[1]
-    w.reference_frame = reference_frame
+args = option_parser.parse(ARGV)
+
+if !replay.empty?
+    replay = Orocos::Log::Replay.open(*replay)
+    replay.register_tasks
+    replay_control = Vizkit.control replay
+end
+
+w = TransformerStatusWindow.new(nil, options)
+w.load_conf(args.first)
+if ref_frame
+    w.reference_frame = ref_frame
 end
 w.show
 Vizkit.exec
+

--- a/bin/rock-transformer
+++ b/bin/rock-transformer
@@ -1,0 +1,107 @@
+#! /usr/bin/env ruby
+
+require 'vizkit'
+
+class TransformerStatusWindow < Qt::Widget
+    attr_reader :vizkit3d, :rbs_setter_toolbox, :reload_button
+
+    def initialize(parent = nil, options = Hash.new)
+        options = Kernel.validate_options options,
+            live: false
+
+        @live = options[:live]
+        @reference_frame = "world_osg"
+        super(parent)
+        create_ui
+    end
+
+    attr_predicate :live?
+
+    def create_ui
+        main_layout = Qt::VBoxLayout.new(self)
+        splitter = Qt::Splitter.new
+        main_layout.add_widget(splitter)
+
+        @rbs_setter_toolbox = Qt::ToolBox.new
+        splitter.add_widget(rbs_setter_toolbox)
+
+        right_pane = Qt::Widget.new
+        layout   = Qt::VBoxLayout.new(right_pane)
+        @vizkit3d = Vizkit.vizkit3d_widget
+        vizkit3d.setAxes(false)
+        @reload_button = Qt::PushButton.new("Reload")
+        reload_button.connect(SIGNAL("clicked()")) do
+            reload
+        end
+        vizkit3d.setTransformer(true)
+        layout.add_widget(reload_button)
+        layout.add_widget(vizkit3d)
+        splitter.add_widget(right_pane)
+
+    end
+
+    attr_reader :reference_frame
+
+    def reference_frame=(frame)
+        @reference_frame = frame
+        vizkit3d.setPluginDataFrame(frame.dup, vizkit3d.grid)
+        vizkit3d.setVisualizationFrame(frame.dup)
+    end
+
+    def load_conf(path)
+        conf = Transformer::Configuration.new
+        conf.load(ARGV.first)
+        conf.each_static_transform do |trsf|
+            vizkit3d.setTransformation(trsf.to.dup, trsf.from.dup, trsf.translation.to_qt, trsf.rotation.to_qt)
+        end
+
+        conf.each_dynamic_transform do |trsf|
+            *task, port = *trsf.producer.split('.')
+            vizkit3d.setTransformation(trsf.to.dup, trsf.from.dup, Eigen::Vector3.Zero.to_qt, Eigen::Quaternion.Identity.to_qt)
+
+            if live?
+                Orocos::Async.proxy(task).port(port).on_data do |sample|
+                    vizkit3d.setTransformation(sample.targetFrame.dup, sample.sourceFrame.dup, sample.position.to_qt, sample.orientation.to_qt)
+                end
+            else
+                widget = Qt::Widget.new
+                layout = Qt::VBoxLayout.new(widget)
+                rbs_editor = Vizkit.default_loader.RigidBodyStateEditor
+                rbs_editor.source_frame.setText trsf.from
+                rbs_editor.target_frame.setText trsf.to
+                layout.add_widget rbs_editor
+                layout.add_stretch
+
+                rbs = Types::Base::Samples::RigidBodyState.Invalid
+                rbs.sourceFrame = trsf.from
+                rbs.targetFrame = trsf.to
+                rbs.position = Eigen::Vector3.Zero
+                rbs.orientation = Eigen::Quaternion.Identity
+                rbs_editor.edit(rbs) do |sample|
+                    vizkit3d.setTransformation(trsf.to.dup, trsf.from.dup, sample.position.to_qt, sample.orientation.to_qt)
+                end
+                rbs_setter_toolbox.add_item widget, "#{trsf.producer} (#{trsf.from} > #{trsf.to})"
+            end
+        end
+
+        @current_conf_path = path
+    end
+
+    def reload
+        while rbs_setter_toolbox.count > 0
+            rbs_setter_toolbox.remove_item 0
+        end
+        if @current_conf_path
+            load_conf(@current_conf_path)
+        end
+    end
+end
+
+w = TransformerStatusWindow.new
+w.load_conf(ARGV.first)
+
+if reference_frame = ARGV[1]
+    w.reference_frame = reference_frame
+end
+w.show
+Vizkit.exec

--- a/bin/rock-transformer
+++ b/bin/rock-transformer
@@ -5,12 +5,15 @@ require 'vizkit'
 class TransformerStatusWindow < Qt::Widget
     attr_reader :vizkit3d, :rbs_setter_toolbox, :reload_button
 
+    attr_reader :rbs_cache
+
     def initialize(parent = nil, options = Hash.new)
         options = Kernel.validate_options options,
             live: false
 
         @live = options[:live]
         @reference_frame = "world_osg"
+        @rbs_cache = Hash.new
         super(parent)
         create_ui
     end
@@ -57,9 +60,9 @@ class TransformerStatusWindow < Qt::Widget
 
         conf.each_dynamic_transform do |trsf|
             *task, port = *trsf.producer.split('.')
-            vizkit3d.setTransformation(trsf.to.dup, trsf.from.dup, Eigen::Vector3.Zero.to_qt, Eigen::Quaternion.Identity.to_qt)
 
             if live?
+                vizkit3d.setTransformation(trsf.to.dup, trsf.from.dup, Eigen::Vector3.Zero.to_qt, Eigen::Quaternion.Identity.to_qt)
                 Orocos::Async.proxy(task).port(port).on_data do |sample|
                     vizkit3d.setTransformation(sample.targetFrame.dup, sample.sourceFrame.dup, sample.position.to_qt, sample.orientation.to_qt)
                 end
@@ -72,11 +75,17 @@ class TransformerStatusWindow < Qt::Widget
                 layout.add_widget rbs_editor
                 layout.add_stretch
 
-                rbs = Types::Base::Samples::RigidBodyState.Invalid
-                rbs.sourceFrame = trsf.from
-                rbs.targetFrame = trsf.to
-                rbs.position = Eigen::Vector3.Zero
-                rbs.orientation = Eigen::Quaternion.Identity
+                rbs = rbs_cache[[trsf.from, trsf.to]]
+                if !rbs
+                    rbs = Types::Base::Samples::RigidBodyState.Invalid
+                    rbs.sourceFrame = trsf.from
+                    rbs.targetFrame = trsf.to
+                    rbs.position = Eigen::Vector3.Zero
+                    rbs.orientation = Eigen::Quaternion.Identity
+                    rbs_cache[[trsf.from, trsf.to]] = rbs
+                end
+
+                vizkit3d.setTransformation(trsf.to.dup, trsf.from.dup, rbs.position.to_qt, rbs.orientation.to_qt)
                 rbs_editor.edit(rbs) do |sample|
                     vizkit3d.setTransformation(trsf.to.dup, trsf.from.dup, sample.position.to_qt, sample.orientation.to_qt)
                 end

--- a/bin/rock-transformer
+++ b/bin/rock-transformer
@@ -6,7 +6,7 @@ class TransformerStatusWindow < Qt::Widget
     attr_reader :main_layout
     attr_reader :vizkit3d, :rbs_setter_toolbox, :reload_button
 
-    attr_reader :rbs_cache
+    attr_reader :rbs_cache, :rbs_editors
 
     def initialize(parent = nil, options = Hash.new)
         options = Kernel.validate_options options,
@@ -15,6 +15,7 @@ class TransformerStatusWindow < Qt::Widget
         @live = options[:live]
         @reference_frame = "world_osg"
         @rbs_cache = Hash.new
+        @rbs_editors = Hash.new
         super(parent)
         create_ui
     end
@@ -61,37 +62,48 @@ class TransformerStatusWindow < Qt::Widget
 
         conf.each_dynamic_transform do |trsf|
             *task, port = *trsf.producer.split('.')
+            task = task.join(".")
 
-            if live?
-                vizkit3d.setTransformation(trsf.to.dup, trsf.from.dup, Eigen::Vector3.Zero.to_qt, Eigen::Quaternion.Identity.to_qt)
-                Orocos::Async.proxy(task).port(port).on_data do |sample|
-                    vizkit3d.setTransformation(sample.targetFrame.dup, sample.sourceFrame.dup, sample.position.to_qt, sample.orientation.to_qt)
-                end
-            else
+            cache_key = [trsf.from, trsf.to]
+
+            rbs = rbs_cache[cache_key]
+            if !rbs
+                rbs = Types::Base::Samples::RigidBodyState.Invalid
+                rbs.sourceFrame = trsf.from
+                rbs.targetFrame = trsf.to
+                rbs.position = Eigen::Vector3.Zero
+                rbs.orientation = Eigen::Quaternion.Identity
+                rbs_cache[cache_key] = rbs
+            end
+            vizkit3d.setTransformation(trsf.to.dup, trsf.from.dup, rbs.position.to_qt, rbs.orientation.to_qt)
+
+            rbs_editor = rbs_editors[cache_key]
+            if !rbs_editor
                 widget = Qt::Widget.new
                 layout = Qt::VBoxLayout.new(widget)
                 rbs_editor = Vizkit.default_loader.RigidBodyStateEditor
-                rbs_editor.source_frame.setText trsf.from
-                rbs_editor.target_frame.setText trsf.to
                 layout.add_widget rbs_editor
                 layout.add_stretch
 
-                rbs = rbs_cache[[trsf.from, trsf.to]]
-                if !rbs
-                    rbs = Types::Base::Samples::RigidBodyState.Invalid
-                    rbs.sourceFrame = trsf.from
-                    rbs.targetFrame = trsf.to
-                    rbs.position = Eigen::Vector3.Zero
-                    rbs.orientation = Eigen::Quaternion.Identity
-                    rbs_cache[[trsf.from, trsf.to]] = rbs
-                end
-
-                vizkit3d.setTransformation(trsf.to.dup, trsf.from.dup, rbs.position.to_qt, rbs.orientation.to_qt)
                 rbs_editor.edit(rbs) do |sample|
                     vizkit3d.setTransformation(trsf.to.dup, trsf.from.dup, sample.position.to_qt, sample.orientation.to_qt)
                 end
+                rbs_editors[cache_key] = rbs_editor
                 rbs_setter_toolbox.add_item widget, "#{trsf.producer} (#{trsf.from} > #{trsf.to})"
             end
+
+            if live?
+                Orocos::Async.proxy(task).port(port).on_data do |sample|
+                    if trsf.from != sample.sourceFrame || trsf.to != sample.targetFrame
+                        puts "received sample from #{task}.#{port} for #{sample.sourceFrame} => #{sample.targetFrame} but expected #{trsf.from} => #{trsf.to}"
+                    end
+                    rbs.position = sample.position
+                    rbs.orientation = sample.orientation
+                    rbs_editor.update
+                    vizkit3d.setTransformation(sample.targetFrame.dup, sample.sourceFrame.dup, sample.position.to_qt, sample.orientation.to_qt)
+                end
+            end
+
         end
 
         @current_conf_path = path
@@ -101,6 +113,8 @@ class TransformerStatusWindow < Qt::Widget
         while rbs_setter_toolbox.count > 0
             rbs_setter_toolbox.remove_item 0
         end
+        rbs_editors.clear
+
         if @current_conf_path
             load_conf(@current_conf_path)
         end


### PR DESCRIPTION
Nobody in his right mind should have to go through the pain of configuring the transformer the way it is supposed to be (assuming that there isn't a tool already I did not learn about).

This PR creates rock-transformer. Workflow-wise, it is meant to be used first as a static design tool. One creates a transformer file and runs

  rock-transformer config/transforms.rb

The UI then allows to visualize the frames, create tests RBS for dynamic producers  and more importantlty *reload* the config file if it is changed by the caller.

Then, there's always the problem of checking that the config file matches what the producers are generating (or that the producers produce what they are supposed to). This can be done live with

  rock-transformer config/transforms.rb --live

or with replay data with

  rock-transformer config/transforms.rb --replay path_to_dataset

Note that it requires a major bugfix on vizkit3d's handling of the transformation graph (rock-core/gui-vizkit3d#5)