### PR TITLE
fix BlockAdapter#bind

### DIFF
--- a/lib/vizkit/plugin.rb
+++ b/lib/vizkit/plugin.rb
@@ -282,8 +282,7 @@ module Vizkit
             end
 
             def bind(object)
-                @object = object
-                self
+                BlockAdapter.new(@block, object)
             end
 
             # Name of the code block which is used for pretty_print of 


### PR DESCRIPTION
The bind call must return a new object, or at least make sure
the receiver is left unchanged. In the case of BlockAdapter, the
@object instance variable was updated, which led all BlockAdapter
built from the same plugin to share the same receiver