### PR TITLE
plot2d: use current samples time instead of time

### DIFF
--- a/lib/vizkit/cplusplus_extensions/plot2d.rb
+++ b/lib/vizkit/cplusplus_extensions/plot2d.rb
@@ -31,7 +31,7 @@ Vizkit::UiLoader::extend_cplusplus_widget_class "Plot2d" do
 
     def time 
         time = if @log_replay
-                   @log_replay.time
+                   @log_replay.current_time
                else
                    Time.now
                end


### PR DESCRIPTION
The time method in replay returns the base_time (start time) of the stream instead of the time of the last sample. Either the documentation or the retuned value are wrong [here](http://rock-robotics.org/stable/api/tools/orocos.rb/Orocos/Log/Replay.html#time-instance_method).

Using the current_time fixes the issue for the plot2d widget.