### PR TITLE
vizkit_item: fix uneeded conversion of datatypes to ruby

### DIFF
--- a/lib/vizkit/vizkit_items.rb
+++ b/lib/vizkit/vizkit_items.rb
@@ -288,8 +288,13 @@ module Vizkit
                     end
                 else
                     @typelib_val = data
-                    rb_sample = @typelib_val.to_ruby
-                    @direct_type = DIRECTLY_DISPLAYED_RUBY_TYPES.any? { |rt| rt === rb_sample }
+                    if @typelib_val.class.convertion_to_ruby
+                        rb_sample = @typelib_val.class.convertion_to_ruby[0]
+                        @direct_type = DIRECTLY_DISPLAYED_RUBY_TYPES.include? rb_sample
+                    else
+                        @direct_type = false
+                    end
+
                     if !@direct_type || @options[:item_type] == :label
                         setEditable false
                     else


### PR DESCRIPTION
This fixing:

https://github.com/rock-core/gui-vizkit/issues/33
https://github.com/rock-core/base-types/pull/45
https://github.com/rock-core/base-types/pull/8

<b> If i got :+1:  i cherry-pich to the release </b>