### PR TITLE
tree view: increase decimals in double spin box

### DIFF
--- a/lib/vizkit/tree_view.rb
+++ b/lib/vizkit/tree_view.rb
@@ -110,7 +110,11 @@ module Vizkit
                 model = data.to_ruby
                 Vizkit::AcknowledgeEditor.new(parent,model,self)
             else
-                super
+                editor = super
+                if editor.is_a? Qt::DoubleSpinBox
+                    editor.setDecimals 10
+                end
+                editor
             end
         end
 


### PR DESCRIPTION
Currently when editing a floating point value in the task inspector the decimals are limited to two.
Since I know that many have issues with that, this PR increases them to ten.

This is of course not the best fix for this issue and it would be nice if there would be a configuration for the decimals. If I have some time a could write something like that. But for now I think hard coded ten is better than hard coded two.