### PR TITLE
use new-style Types API

### DIFF
--- a/lib/vizkit/cplusplus_extensions/vizkit_widget.rb
+++ b/lib/vizkit/cplusplus_extensions/vizkit_widget.rb
@@ -378,7 +378,7 @@ module VizkitPluginLoaderExtension
 
     def update(data, port_name)
         if @connected_to_broadcaster
-            if use_transformer_broadcaster? && data.class == Types::Transformer::ConfigurationState
+            if use_transformer_broadcaster? && data.class == Types.transformer.ConfigurationState
                 pushTransformerConfiguration(data)
                 return
             end

--- a/lib/vizkit/plugin.rb
+++ b/lib/vizkit/plugin.rb
@@ -65,8 +65,8 @@ module Vizkit
         # @example
         #   normalize_obj(123) => ["Fixnum", "Integer", "Numeric", "Object", "BasicObject"]
         #   normalize_obj("/base/samples/frame/Frame") => ["/base/samples/frame/Frame", "Typelib::CompoundType", "Typelib::Type", "Object", "BasicObject"]
-        #   normalize_obj(Types::Base::Samples::Frame::Frame) => ["/base/samples/frame/Frame", "Typelib::CompoundType", "Typelib::Type", "Object", "BasicObject"]
-        #   normalize_obj(Types::Base::Samples::Frame::Frame.new) => ["/base/samples/frame/Frame", "Typelib::CompoundType", "Typelib::Type", "Object", "BasicObject"]
+        #   normalize_obj(Types.base.samples.frame.Frame) => ["/base/samples/frame/Frame", "Typelib::CompoundType", "Typelib::Type", "Object", "BasicObject"]
+        #   normalize_obj(Types.base.samples.frame.Frame.new) => ["/base/samples/frame/Frame", "Typelib::CompoundType", "Typelib::Type", "Object", "BasicObject"]
         def self.normalize_obj(object,include_super=true)
             return Array.new unless object
             names = if object.respond_to? :superclass
@@ -128,7 +128,7 @@ module Vizkit
         #   if the given string does not match a ruby class name of a typelib
         #   class.
         # @example
-        #   to_typelib_name("Types::Base::Angle" => "/base/Angle"
+        #   to_typelib_name("Types.base.Angle" => "/base/Angle"
         #
         def self.to_typelib_name(class_name)
             class_name =~ /^Types(::.*::)(\w*)/

--- a/lib/vizkit/widgets/base_types_editor/angle_editor.rb
+++ b/lib/vizkit/widgets/base_types_editor/angle_editor.rb
@@ -33,7 +33,7 @@ class AngleEditor < Qt::Widget
         @button.connect(SIGNAL("clicked()")) do 
             if(@callback_angle)
                 Orocos.load_typekit_for("/base/Angle",false)
-                angle = @angle ? @angle : Types::Base::Angle.new
+                angle = @angle ? @angle : Types.base.Angle.new
                 angle.rad = @spin_box.value()*Math::PI/180
                 @callback_angle.call(angle)
             else

--- a/lib/vizkit/widgets/base_types_editor/rigid_body_state.rb
+++ b/lib/vizkit/widgets/base_types_editor/rigid_body_state.rb
@@ -11,7 +11,7 @@ class RigidBodyStateEditor
         attr_reader :edited_sample
 
         def init
-            @edited_sample = Types::Base::Samples::RigidBodyState.new
+            @edited_sample = Types.base.samples.RigidBodyState.new
             @callback_fct = nil
             @timer = Qt::Timer.new
             start_value.connect(SIGNAL('clicked()')) do

--- a/test/test_connector_objects.rb
+++ b/test/test_connector_objects.rb
@@ -85,7 +85,7 @@ describe "ConnectorObjects" do
 
             describe "write" do 
                 it "must write a value to the slot" do
-                    sample = Types::Base::Samples::Frame::Frame.new.zero!
+                    sample = Types.base.samples.frame.Frame.new.zero!
                     sample.time = Time.now
                     obj = ConnectorSlot.new(@@widget,"setFrame")
                     obj.write Hash.new,sample
@@ -93,7 +93,7 @@ describe "ConnectorObjects" do
                 end
 
                 it "must write a value if the slot is a ruby method" do
-                    sample = Types::Base::Samples::Frame::Frame.new.zero!
+                    sample = Types.base.samples.frame.Frame.new.zero!
                     sample.time = Time.now
                     obj = ConnectorSlot.new(@@widget,"ruby_method")
                     obj.write Hash.new,sample


### PR DESCRIPTION
It is much faster, and much nicer (no ambiguities possible in the
C++-to-Ruby naming convention)