### PR TITLE
Make it possible to display remission from a DepthMap using ImageView

### DIFF
--- a/lib/vizkit/cplusplus_extensions/image_view_widget.rb
+++ b/lib/vizkit/cplusplus_extensions/image_view_widget.rb
@@ -67,4 +67,5 @@ end
 Vizkit::UiLoader.register_default_widget_for("ImageView","/base/samples/DistanceImage",:display)
 Vizkit::UiLoader.register_default_widget_for("ImageView","/base/samples/frame/Frame",:display)
 Vizkit::UiLoader.register_default_widget_for("ImageView","/base/samples/frame/FramePair",:display2)
+Vizkit::UiLoader.register_default_widget_for("ImageView","/base/samples/DepthMap",:display)
 


### PR DESCRIPTION
A `DepthMap` often contains remission information (usually reflectance of IR light) which can be of interest. Requires https://github.com/rock-core/gui-rock_widget_collection/pull/24 to be merged first.