### PR TITLE
Bitfield type support

### DIFF
--- a/lib/vizkit/vizkit_items.rb
+++ b/lib/vizkit/vizkit_items.rb
@@ -231,8 +231,9 @@ module Vizkit
         def setData(data,role = Qt::UserRole+1)
             return super if role != Qt::EditRole || data.isNull
             item_val = @typelib_val.to_ruby
-            val = from_variant data,item_val.class
-            return false unless val != nil
+            val = from_variant data, item_val
+            return false if !val
+            val = Typelib.from_ruby(val, @typelib_val.class)
             update(val)
             modified!
         end

--- a/lib/vizkit/vizkit_items.rb
+++ b/lib/vizkit/vizkit_items.rb
@@ -582,7 +582,7 @@ module Vizkit
 
         def initialize(port,options = Hash.new)
             super
-            @listener = port.on_data do |data|
+            @listener = port.on_raw_data do |data|
                 # depending on the type we receive none typelip objects
                 # therefore if have to initialize it with a new sample
                 begin 
@@ -653,7 +653,7 @@ module Vizkit
             @options.merge! options
 
             @property = property
-            @listener = @property.on_change do |data|
+            @listener = @property.on_raw_change do |data|
                 # depending on the type we receive none typelip objects
                 # therefore if have to initialize it with a new sample
                 begin

--- a/lib/vizkit/vizkit_items.rb
+++ b/lib/vizkit/vizkit_items.rb
@@ -129,21 +129,24 @@ module Vizkit
            super
         end
 
-        def from_variant(data,klass)
-            if klass == Integer || klass == Fixnum
-                data.to_i
-            elsif klass == Float
-                data.to_f
-            elsif klass == String
+        def from_variant(data, expected_value)
+            case expected_value
+            when Numeric
+                if expected_value.integer?
+                    data.to_i
+                else
+                    data.to_f
+                end
+            when String
                 data.toString.to_s
-            elsif klass == Time
+            when Time
                 Time.at(data.toDateTime.toTime_t)
-            elsif klass == Symbol
+            when Symbol
                 data.toString.to_sym
-            elsif klass == (FalseClass) || klass == (TrueClass)
+            when true, false
                 data.toBool
             else
-                raise "cannot convert #{data.toString} to #{klass} - no conversion"
+                raise "cannot convert #{data.toString} to #{expected_value.class} - no conversion"
             end
         end
     end


### PR DESCRIPTION
Along with https://github.com/orocos-toolchain/typelib/pull/103, this allows to interpret bitfield types by associating them with an enum type that describes the bits, e.g. with

~~~
enum FIELD_VALUES
{
  VALUE0 = 1,
  VALUE1 = 2,
  VALUE2 = 4
}

struct Status
{
    /* The system status
     *
     * @meta bitfield /libname/FIELD_VALUES
     */
    uint16_t values;
}
~~~

the task inspector will show each set field instead of the raw integer value.

https://github.com/orocos-toolchain/orogen/pull/98 ensures that types related by metadata are all present at definition time (and are therefore available for e.g. vizkit in this case)