### PR TITLE
add feature to remove graph from plot2d

### DIFF
--- a/lib/vizkit/connection_manager.rb
+++ b/lib/vizkit/connection_manager.rb
@@ -44,7 +44,7 @@ module Vizkit
             end
         end
 
-        def disconnect(port=nil, keep_port=true)
+        def disconnect(port=nil, keep_port: true)
             if port
                 @on_data_listeners[port].each do |l|
                     l.stop
@@ -60,8 +60,11 @@ module Vizkit
                 
             else
                 @on_data_listeners.keys.each do |key|
-                    disconnect(key, keep_port)
+                    disconnect(key, keep_port: true)
                 end
+                
+                @on_data_listeners.clear unless keep_port
+                @on_reachable_listeners.clear unless keep_port
             end
         end
 

--- a/lib/vizkit/connection_manager.rb
+++ b/lib/vizkit/connection_manager.rb
@@ -31,10 +31,6 @@ module Vizkit
             end
             return nil
         end
-
-        def remove_port(port)
-            @on_data_listeners.delete(port)
-        end
         
         def listening?(port = nil)
             if port
@@ -48,17 +44,23 @@ module Vizkit
             end
         end
 
-        def disconnect(port=nil)
+        def disconnect(port=nil, keep_port=true)
             if port
                 @on_data_listeners[port].each do |l|
                     l.stop
                 end
+                
+                @on_data_listeners.delete(port) unless keep_port
+                
                 @on_reachable_listeners[port].each do |l|
                     l.stop
                 end
+                
+                @on_reachable_listeners.delete(port) unless keep_port
+                
             else
                 @on_data_listeners.keys.each do |key|
-                    disconnect(key)
+                    disconnect(key, keep_port)
                 end
             end
         end

--- a/lib/vizkit/connection_manager.rb
+++ b/lib/vizkit/connection_manager.rb
@@ -23,6 +23,19 @@ module Vizkit
             end
         end
 
+        def find_port_by_name(pname)
+            @on_data_listeners.keys.each do |key|
+                if key.full_name == pname 
+                    return key
+                end
+            end
+            return nil
+        end
+
+        def remove_port(port)
+            @on_data_listeners.delete(port)
+        end
+        
         def listening?(port = nil)
             if port
                 @on_data_listeners[port].find do |l|

--- a/lib/vizkit/cplusplus_extensions/plot2d.rb
+++ b/lib/vizkit/cplusplus_extensions/plot2d.rb
@@ -159,7 +159,7 @@ Vizkit::UiLoader::extend_cplusplus_widget_class "Plot2d" do
                             cur_port = connection_manager().find_port_by_name(graph.name)
                             
                             if cur_port
-                                connection_manager().disconnect(cur_port, false)
+                                connection_manager().disconnect(cur_port,  keep_port: false)
                             else
                                 break
                             end 
@@ -167,6 +167,7 @@ Vizkit::UiLoader::extend_cplusplus_widget_class "Plot2d" do
                         
                         @graphs.delete graph.name
                         removeGraph(itemIdx.to_i())
+                        @needs_update = true
                     end
                 end
             end

--- a/lib/vizkit/cplusplus_extensions/plot2d.rb
+++ b/lib/vizkit/cplusplus_extensions/plot2d.rb
@@ -159,8 +159,7 @@ Vizkit::UiLoader::extend_cplusplus_widget_class "Plot2d" do
                             cur_port = connection_manager().find_port_by_name(graph.name)
                             
                             if cur_port
-                                connection_manager().disconnect(cur_port)
-                                connection_manager().remove_port(cur_port)
+                                connection_manager().disconnect(cur_port, false)
                             else
                                 break
                             end 


### PR DESCRIPTION
I'm unsure if this is the right way to disconnect and especially why the port has to be deleted from on_data_listeners completely. If it is kept, we will have multiple ports with the same name if the signal is plotted again after removing.

note: requires corresponding merge in gui-rock_widget_collection
