### PR TITLE
Struct Viewer - text color to black

### DIFF
--- a/lib/vizkit/widgets/struct_viewer/struct_viewer_window.ui
+++ b/lib/vizkit/widgets/struct_viewer/struct_viewer_window.ui
@@ -80,6 +80,15 @@
      <property name="palette">
       <palette>
        <active>
+        <colorrole role="Text">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>0</red>
+           <green>0</green>
+           <blue>0</blue>
+          </color>
+         </brush>
+        </colorrole>
         <colorrole role="Base">
          <brush brushstyle="SolidPattern">
           <color alpha="255">
@@ -100,6 +109,15 @@
         </colorrole>
        </active>
        <inactive>
+        <colorrole role="Text">
+         <brush brushstyle="SolidPattern">
+          <color alpha="255">
+           <red>0</red>
+           <green>0</green>
+           <blue>0</blue>
+          </color>
+         </brush>
+        </colorrole>
         <colorrole role="Base">
          <brush brushstyle="SolidPattern">
           <color alpha="255">


### PR DESCRIPTION
Struct viewer with text font color to black. Otherwise, the text is not visible with Qt4 with Ubuntu 18.04 because by default is white. So, I set it to black as it's also for the task_inspector.

Qt4 UI: change font color in struct_viewer from white to black. the white color with yellow background is not visible.