### PR TITLE
fix occasional NaN in VirtualJoystick heading

### DIFF
--- a/lib/vizkit/cplusplus_extensions/virtual_joystick.rb
+++ b/lib/vizkit/cplusplus_extensions/virtual_joystick.rb
@@ -5,15 +5,17 @@ Vizkit::UiLoader.register_control_for("VirtualJoystick", "/base/commands/Motion2
 
     widget.connect(SIGNAL('axisChanged(double,double)')) do |x, y|
         value = Types.base.commands.Motion2D.new
-	value.translation = x
-	value.rotation =
-	    if x == 0 && y == 0
-		0
-	    else
-		-y.abs() * Math::atan2(y, x.abs())
-	    end
+        # the heading from Motion2D.new here is only almost 0 (2.2469905698352052e-307) due to cpp/ruby, set it to exactly 0 (as Motion2d initializes it in its constructor) to avoud occational NaN
+        value.heading.rad = 0
+        value.translation = x
+        value.rotation =
+    	    if x == 0 && y == 0
+	        	0
+	        else
+		        -y.abs() * Math::atan2(y, x.abs())
+	        end
         if block
-	    block.call(value)
+	        block.call(value)
         else
             port.write value do
             end

--- a/lib/vizkit/cplusplus_extensions/virtual_joystick.rb
+++ b/lib/vizkit/cplusplus_extensions/virtual_joystick.rb
@@ -5,7 +5,7 @@ Vizkit::UiLoader.register_control_for("VirtualJoystick", "/base/commands/Motion2
 
     widget.connect(SIGNAL('axisChanged(double,double)')) do |x, y|
         value = Types.base.commands.Motion2D.new
-        # the heading from Motion2D.new here is only almost 0 (2.2469905698352052e-307) due to cpp/ruby, set it to exactly 0 (as Motion2d initializes it in its constructor) to avoud occational NaN
+        # the heading from Motion2D.new here is only almost 0 (2.2469905698352052e-307) due to cpp/ruby, set it to exactly 0 (as Motion2d initializes it in its constructor) to avoid occasional NaN
         value.heading.rad = 0
         value.translation = x
         value.rotation =


### PR DESCRIPTION
I guess due to cpp/ruby conversion the heading is sometimes only almost 0 and sometimes NaN when the VirtialJoystick writes Motion2d Commands, as the Motion2d class is initializing the heading with 0 itself (rather NaN as "unset"), reset it to a real 0 in ruby.

I guess the NaN resuls from having a really small ruby value (as 4.65696114160106e-310) in the motion2d and when converting back into cpp it results in a NaN.

As the VirtualJoystick cannot the the heading anyways, it ins now re-initialized with 0 before writing to the port